### PR TITLE
Fix text question submission trimming

### DIFF
--- a/app/src/screens/GameScreen.tsx
+++ b/app/src/screens/GameScreen.tsx
@@ -88,7 +88,7 @@ export default function GameScreen({ route, navigation }: Props) {
     if (mode === GameMode.AI_GUESSING) {
       gameActions.submitUserAnswer(textToSubmit, 'text');
     } else {
-      gameActions.sendQuestion(undefined, question);
+      gameActions.sendQuestion(textToSubmit, question);
     }
     setQuestion('');
   };


### PR DESCRIPTION
## Summary
- ensure GameScreen passes trimmed text to the sendQuestion action
- capture GameInput props in the GameScreen test to drive text submission behaviour
- add a regression test verifying whitespace is trimmed before dispatching the question

## Testing
- npm test -- --runTestsByPath src/screens/__tests__/GameScreen.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de1cbcb8088328919dc3a48f101376